### PR TITLE
Ensure round-trip serialization is consistent

### DIFF
--- a/src/main/java/com/opower/unitsofmeasure/UnitJsonDeserializer.java
+++ b/src/main/java/com/opower/unitsofmeasure/UnitJsonDeserializer.java
@@ -25,7 +25,7 @@ public class UnitJsonDeserializer extends StdScalarDeserializer<Unit> {
     public Unit deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         JsonToken currentToken = jsonParser.getCurrentToken();
         if (currentToken == JsonToken.VALUE_STRING) {
-            return UCUMFormat.getInstance(UCUMFormat.Variant.CASE_INSENSITIVE).parse(jsonParser.getText(), new ParsePosition(0));
+            return UCUMFormat.getInstance(UCUMFormat.Variant.CASE_SENSITIVE).parse(jsonParser.getText(), new ParsePosition(0));
         }
         throw deserializationContext.wrongTokenException(jsonParser, JsonToken.VALUE_STRING, "Expected unit value in String format");
     }

--- a/src/test/java/com/opower/unitsofmeasure/UnitJacksonModuleTest.java
+++ b/src/test/java/com/opower/unitsofmeasure/UnitJacksonModuleTest.java
@@ -14,12 +14,12 @@ import javax.measure.Unit;
 
 import static org.junit.Assert.*;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import systems.uom.ucum.UCUM;
 import static tec.uom.se.AbstractUnit.ONE;
 import static tec.uom.se.unit.MetricPrefix.KILO;
+import static tec.uom.se.unit.MetricPrefix.MEGA;
 import static tec.uom.se.unit.MetricPrefix.MILLI;
 import tec.uom.se.unit.Units;
 
@@ -104,10 +104,16 @@ public class UnitJacksonModuleTest {
     }
 
     @Test
-    @Ignore("solve km formatting") // TODO solve km parsing
     public void testParseLengthKm() throws Exception {
         Unit<?> parsedUnit = parse("\"km\"", Unit.class);
         assertEquals("The Unit<Length> in the parsed JSON doesn't match", KILO(Units.METRE), parsedUnit);
+    }
+
+    @Test
+    public void testRoundTripSerialization() throws Exception {
+        String serialized = serialize(MEGA(UCUM.METER));
+        Unit<?> parsedUnit = parse(serialized, Unit.class);
+        assertEquals("The Unit<Length> in the parsed JSON doesn't match", MEGA(UCUM.METER), parsedUnit);
     }
 
     protected String serialize(Object objectToSerialize) throws IOException {


### PR DESCRIPTION
The serialization/de-serialization is not consistent, so if you are trying to use this to map between JSON and back, then it doesn't work for a subset of UCUM units.

I have also removed the `@Ignore` on the km test, but happy to revert this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/jackson-module-unitsofmeasure/19)
<!-- Reviewable:end -->
